### PR TITLE
Attach question meshes to table so cards render

### DIFF
--- a/main.js
+++ b/main.js
@@ -627,6 +627,12 @@ function startQuestionRound(tbounds) {
   answersGroup = makeAnswerCards(currentQ.options.map(o => o.en));
   imageCard = makeImageCard({ hint: currentQ.prompt.hint, de: currentQ.prompt.de });
 
+  const table = tablePlacer?.table;
+  if (table) {
+    if (imageCard && !imageCard.parent) table.add(imageCard);
+    if (answersGroup && !answersGroup.parent) table.add(answersGroup);
+  }
+
   answersGroup.children.forEach((card, idx) => {
     card.userData.correct = (idx === currentQ.correctIndex);
   });
@@ -653,7 +659,12 @@ function startQuestionRound(tbounds) {
 }
 
 function relayoutLocal(tbounds) {
-  layoutQuestionAdaptive(tablePlacer.table, tbounds, imageCard, answersGroup);
+  const table = tablePlacer?.table;
+  if (table) {
+    if (imageCard && !imageCard.parent) table.add(imageCard);
+    if (answersGroup && !answersGroup.parent) table.add(answersGroup);
+  }
+  layoutQuestionAdaptive(table, tbounds, imageCard, answersGroup);
   hud.updateControls({
     topic: gameState.selectedTopic || "All",
     roundSize: gameState.roundSize,


### PR DESCRIPTION
## Summary
- attach newly created prompt and answer meshes to the table once they are generated
- ensure relayout keeps the meshes parented to the table before computing positions

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7b1bccf78832e934318f74fcb8ca8