### PR TITLE
Render cards double-sided on table

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -7,7 +7,14 @@ function makeCardMesh(w=0.16, h=0.10, text="", bg=0x243b2f) {
 
   const plane = new THREE.Mesh(
     new THREE.PlaneGeometry(w, h),
-    new THREE.MeshBasicMaterial({ color: bg, transparent:true, opacity:1.0, depthTest:false, depthWrite:false })
+    new THREE.MeshBasicMaterial({
+      color: bg,
+      transparent: true,
+      opacity: 1.0,
+      depthTest: false,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    })
   );
   plane.name = "cardPlane";
 
@@ -36,7 +43,13 @@ function makeCardMesh(w=0.16, h=0.10, text="", bg=0x243b2f) {
 
   const txt = new THREE.Mesh(
     new THREE.PlaneGeometry(w*0.98, h*0.98),
-    new THREE.MeshBasicMaterial({ map: tex, transparent:true, depthTest:false, depthWrite:false })
+    new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    })
   );
   txt.position.set(0, 0, 0.001);
 
@@ -88,7 +101,13 @@ function makeHintMesh(w=0.18, h=0.14, hint="", de="") {
 
   const plane = new THREE.Mesh(
     new THREE.PlaneGeometry(w, h),
-    new THREE.MeshBasicMaterial({ map: tex, transparent:true, depthTest:false, depthWrite:false })
+    new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    })
   );
 
   group.add(plane);

--- a/main.js
+++ b/main.js
@@ -627,6 +627,12 @@ function startQuestionRound(tbounds) {
   answersGroup = makeAnswerCards(currentQ.options.map(o => o.en));
   imageCard = makeImageCard({ hint: currentQ.prompt.hint, de: currentQ.prompt.de });
 
+  const table = tablePlacer?.table;
+  if (table) {
+    if (imageCard && !imageCard.parent) table.add(imageCard);
+    if (answersGroup && !answersGroup.parent) table.add(answersGroup);
+  }
+
   answersGroup.children.forEach((card, idx) => {
     card.userData.correct = (idx === currentQ.correctIndex);
   });
@@ -653,7 +659,12 @@ function startQuestionRound(tbounds) {
 }
 
 function relayoutLocal(tbounds) {
-  layoutQuestionAdaptive(tablePlacer.table, tbounds, imageCard, answersGroup);
+  const table = tablePlacer?.table;
+  if (table) {
+    if (imageCard && !imageCard.parent) table.add(imageCard);
+    if (answersGroup && !answersGroup.parent) table.add(answersGroup);
+  }
+  layoutQuestionAdaptive(table, tbounds, imageCard, answersGroup);
   hud.updateControls({
     topic: gameState.selectedTopic || "All",
     roundSize: gameState.roundSize,


### PR DESCRIPTION
## Summary
- render answer card background and text planes double-sided so they remain visible after table rotation
- render prompt card plane double-sided to ensure the hint stays visible from either side

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7b1bccf78832e934318f74fcb8ca8