### PR TITLE
Adjust HUD summary placement

### DIFF
--- a/config.js
+++ b/config.js
@@ -71,6 +71,10 @@ export const CONFIG = {
       lift: 0.30,          // vorher 0.22 – jetzt höher
       frontOffsetZ: 0.04   // leicht vorziehen
     },
+    summary: {
+      lift: 0.50,
+      frontOffsetZ: 0.06
+    },
     // höhere Render-Ordnung für die Summary, damit sie sicher oben liegt
     zorder: {
       base: 10,


### PR DESCRIPTION
## Summary
- add a summary placement config block with higher lift and forward offset so the HUD summary panel no longer falls back to defaults

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ed328580832eb8cf5db43ee23dc1