### PR TITLE
Adjust initial table yaw handling

### DIFF
--- a/placement.js
+++ b/placement.js
@@ -58,7 +58,7 @@ export class TablePlacer {
     // --- Platte (Spielfeld)
     this.table = new THREE.Group();
     this.table.name = "TableRoot";
-    this.table.rotation.y = Math.PI;
+    this.table.rotation.y = 0; // start unrotated; final orientation applied after placement
     this.plate = this._makePlate(this.width, this.height);
     this.table.add(this.plate);
 
@@ -199,6 +199,8 @@ export class TablePlacer {
     // nach Platzierung Platte zeigen
     this.setVisible(true);
     this.enableHandles(true);
+    // apply default facing after placement so prompt/answers layout keep orientation
+    this.table.rotation.y = Math.PI;
     return this.getBounds();
   }
 


### PR DESCRIPTION
## Summary
- start the placement table without the initial π yaw so it begins facing the opposite direction while positioning
- reapply the default 180° orientation after placement ends to keep prompts and answers facing the intended direction

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7ff1f29f8832e8b7f66ee1bf479fe